### PR TITLE
implement batch products import

### DIFF
--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -39,6 +39,11 @@ const serverlessConfiguration: AWS = {
               "s3:*"
             ],
             Resource: "arn:aws:s3:::${self:custom.s3BucketName}/*"
+          },
+          {
+            Effect: 'Allow',
+            Action: 'sqs:*',
+            Resource: 'arn:aws:sqs:eu-west-1:854170183769:catalogItemsQueue'
           }
         ]
       }

--- a/import-service/src/functions/importFileParser/handler.ts
+++ b/import-service/src/functions/importFileParser/handler.ts
@@ -8,6 +8,7 @@ const importFileParser: ValidatedEventS3Event = async (event) => {
   console.log('event', event)
 
   const s3 = new AWS.S3()
+  const sqs = new AWS.SQS()
 
   for (const record of event.Records) {
     const Bucket = record.s3.bucket.name;
@@ -19,7 +20,10 @@ const importFileParser: ValidatedEventS3Event = async (event) => {
 
     try {
       for await (const data of parser) {
-        console.log(data);
+        sqs.sendMessage({
+          QueueUrl: process.env.SQS_URL,
+          MessageBody: JSON.stringify(data),
+        }, (err, data) => console.log(err, data))
 
         await s3.copyObject({
           Bucket,

--- a/import-service/src/functions/importFileParser/index.ts
+++ b/import-service/src/functions/importFileParser/index.ts
@@ -17,4 +17,8 @@ export default {
       },
     },
   ],
+  environment: {
+    // TODO: take that from products-service
+    SQS_URL: 'https://sqs.eu-west-1.amazonaws.com/854170183769/catalogItemsQueue',
+  }
 };

--- a/product-service/jest.config.js
+++ b/product-service/jest.config.js
@@ -4,5 +4,6 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@libs(.*)$': '<rootDir>/src/libs/$1',
+    '^src(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/product-service/serverless.ts
+++ b/product-service/serverless.ts
@@ -3,6 +3,7 @@ import type { AWS } from '@serverless/typescript';
 import getProductsList from '@functions/getProductsList';
 import getProductsById from '@functions/getProductsById';
 import createProduct from '@functions/createProduct';
+import catalogBatchProcess from '@functions/catalogBatchProcess';
 
 const serverlessConfiguration: AWS = {
   service: 'product-service',
@@ -38,13 +39,20 @@ const serverlessConfiguration: AWS = {
               "dynamodb:DeleteItem"
             ],
             Resource: "arn:aws:dynamodb:eu-west-1:*:*"
+          },
+          {
+            Effect: 'Allow',
+            Action: 'sns:*',
+            Resource: {
+              Ref: 'SNSTopic'
+            }
           }
         ]
       }
     }
   },
   // import the function via paths
-  functions: { getProductsList, getProductsById, createProduct },
+  functions: { getProductsList, getProductsById, createProduct, catalogBatchProcess },
   package: { individually: true },
   custom: {
     autoswagger: {
@@ -105,6 +113,28 @@ const serverlessConfiguration: AWS = {
           ProvisionedThroughput: {
             ReadCapacityUnits: 1,
             WriteCapacityUnits: 1
+          }
+        }
+      },
+      SQSQueue: {
+        Type: 'AWS::SQS::Queue',
+        Properties: {
+          QueueName: 'catalogItemsQueue'
+        }
+      },
+      SNSTopic: {
+        Type: 'AWS::SNS::Topic',
+        Properties: {
+          TopicName: 'createProductTopic'
+        }
+      },
+      SNSSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: 'yevgeny_yakushev@epam.com',
+          Protocol: 'email',
+          TopicArn: {
+            Ref: 'SNSTopic'
           }
         }
       }

--- a/product-service/src/functions/catalogBatchProcess/handler.test.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.test.ts
@@ -1,0 +1,37 @@
+
+import { catalogBatchProcess } from './handler'
+import * as utils from 'src/utils'
+
+describe('/catalogBatchProcess', () => {
+    const products = [
+        { id: 1, title: 'product 1' },
+        { id: 2, title: 'product 2' },
+    ]
+
+    const generateSQSEvent = (): any => ({
+        Records: products.map((product) => ({ body: JSON.stringify(product) }))
+    })
+
+    test('success response', async () => {
+        const createProductTransactionSpy = jest.spyOn(utils, 'createProductTransaction').mockResolvedValue(undefined)
+        const sendSNSMessageSpy = jest.spyOn(utils, 'sendSNSMessage').mockResolvedValue(undefined)
+
+        await catalogBatchProcess(generateSQSEvent(), null, null)
+        
+        expect(utils.createProductTransaction).toHaveBeenCalledTimes(products.length)
+        expect(utils.sendSNSMessage).toHaveBeenCalledTimes(1)
+
+        createProductTransactionSpy.mockClear()
+        sendSNSMessageSpy.mockClear()
+    })
+
+    test('error response', async () => {
+        jest.spyOn(utils, 'createProductTransaction').mockRejectedValue(undefined)
+        jest.spyOn(utils, 'sendSNSMessage').mockResolvedValue(undefined)
+
+        await catalogBatchProcess(generateSQSEvent(), null, null)
+        
+        expect(utils.createProductTransaction).toHaveBeenCalledTimes(products.length)
+        expect(utils.sendSNSMessage).not.toHaveBeenCalled()
+    })
+});

--- a/product-service/src/functions/catalogBatchProcess/handler.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.ts
@@ -1,11 +1,8 @@
-import AWS from 'aws-sdk'
 import { ValidatedEventSQSEvent } from '@libs/sqs';
-import { createProductTransaction } from 'src/utils';
+import { createProductTransaction, sendSNSMessage } from 'src/utils';
 
 export const catalogBatchProcess: ValidatedEventSQSEvent = async (event) => {
     console.log('event', event)
-
-    const sns = new AWS.SNS()
 
     try {
         const products = []
@@ -19,11 +16,11 @@ export const catalogBatchProcess: ValidatedEventSQSEvent = async (event) => {
 
         await Promise.all(productsPromise)
 
-        await sns.publish({
+        await sendSNSMessage({
             Subject: 'Products have been created',
             Message: JSON.stringify(products),
             TopicArn: process.env.SNS_ARN
-        }, async (err, data) => console.log(err, data)).promise()
+        })
     } catch (err) {
         console.log(err)
     }

--- a/product-service/src/functions/catalogBatchProcess/handler.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.ts
@@ -1,0 +1,32 @@
+import AWS from 'aws-sdk'
+import { ValidatedEventSQSEvent } from '@libs/sqs';
+import { createProductTransaction } from 'src/utils';
+
+export const catalogBatchProcess: ValidatedEventSQSEvent = async (event) => {
+    console.log('event', event)
+
+    const sns = new AWS.SNS()
+
+    try {
+        const products = []
+        const productsPromise = []
+
+        event.Records.forEach(async ({ body }) => {
+            const item = JSON.parse(body)
+            products.push(item)
+            productsPromise.push(createProductTransaction(item))
+        })
+
+        await Promise.all(productsPromise)
+
+        await sns.publish({
+            Subject: 'Products have been created',
+            Message: JSON.stringify(products),
+            TopicArn: process.env.SNS_ARN
+        }, async (err, data) => console.log(err, data)).promise()
+    } catch (err) {
+        console.log(err)
+    }
+};
+
+export const main = catalogBatchProcess;

--- a/product-service/src/functions/catalogBatchProcess/index.ts
+++ b/product-service/src/functions/catalogBatchProcess/index.ts
@@ -1,0 +1,22 @@
+import { handlerPath } from '@libs/handler-resolver';
+
+export default {
+    handler: `${handlerPath(__dirname)}/handler.main`,
+    events: [
+        {
+            sqs: {
+                arn: {
+                    'Fn::GetAtt': ['SQSQueue', 'Arn']
+                },
+                batchSize: 5
+            }
+        },
+    ],
+    environment: {
+        PRODUCTS_TABLE_NAME: 'productsTable',
+        STOCKS_TABLE_NAME: 'stocksTable',
+        SNS_ARN: {
+            Ref: 'SNSTopic'
+        }
+    }
+};

--- a/product-service/src/functions/createProduct/handler.ts
+++ b/product-service/src/functions/createProduct/handler.ts
@@ -2,41 +2,16 @@ import type { ValidatedEventAPIGatewayProxyEvent } from '@libs/api-gateway';
 import { formatJSONResponse } from '@libs/api-gateway';
 import { middyfy } from '@libs/lambda';
 import cors from '@middy/http-cors';
-import crypto from 'crypto'
-import AWS from 'aws-sdk'
-
-const dynamo = new AWS.DynamoDB.DocumentClient()
 
 import schema from './schema';
+import { createProductTransaction } from 'src/utils';
 
 export const createProduct: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) => {
     console.log('event', event)
 
     try {
         const { count, ...item } = event.body
-
-        const id = crypto.randomUUID()
-
-        await dynamo.transactWrite({
-            TransactItems: [
-                {
-                    Put: {
-                        TableName: process.env.PRODUCTS_TABLE_NAME,
-                        Item: { id, ...item }
-                    },
-                },
-                {
-                    Put: {
-                        TableName: process.env.STOCKS_TABLE_NAME,
-                        Item: {
-                            product_id: id,
-                            count
-                        }
-                    },
-                },
-            ],
-        }).promise()
-
+        await createProductTransaction(event.body)
         return formatJSONResponse({ ...item, count })
     } catch (err) {
         return formatJSONResponse({ message: err.message }, 400)

--- a/product-service/src/libs/sqs.ts
+++ b/product-service/src/libs/sqs.ts
@@ -1,0 +1,3 @@
+import type { SQSHandler } from "aws-lambda/trigger/sqs"
+
+export type ValidatedEventSQSEvent = SQSHandler

--- a/product-service/src/utils/index.ts
+++ b/product-service/src/utils/index.ts
@@ -30,3 +30,8 @@ export const createProductTransaction = async (data: FromSchema<typeof schema>) 
         ],
     }).promise()
 }
+
+export const sendSNSMessage = async (params: AWS.SNS.PublishInput, callback = async (err, data) => console.log(err, data)) => {
+    const sns = new AWS.SNS()
+    return await sns.publish(params, callback).promise()
+}

--- a/product-service/src/utils/index.ts
+++ b/product-service/src/utils/index.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto'
+import AWS from 'aws-sdk'
+import type { FromSchema } from "json-schema-to-ts";
+import schema from '@functions/createProduct/schema';
+
+const dynamo = new AWS.DynamoDB.DocumentClient()
+
+export const createProductTransaction = async (data: FromSchema<typeof schema>) => {
+    const { count, ...item } = data
+
+    const id = crypto.randomUUID()
+
+    await dynamo.transactWrite({
+        TransactItems: [
+            {
+                Put: {
+                    TableName: process.env.PRODUCTS_TABLE_NAME,
+                    Item: { id, ...item }
+                },
+            },
+            {
+                Put: {
+                    TableName: process.env.STOCKS_TABLE_NAME,
+                    Item: {
+                        product_id: id,
+                        count
+                    }
+                },
+            },
+        ],
+    }).promise()
+}

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
-  products: "https://8ox5spfdif.execute-api.eu-west-1.amazonaws.com/dev",
-  order: "https://8ox5spfdif.execute-api.eu-west-1.amazonaws.com/dev",
+  products: "https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev",
+  order: "https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://pncu28d3e3.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://8ox5spfdif.execute-api.eu-west-1.amazonaws.com/dev",
-  cart: "https://8ox5spfdif.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: "https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev",
+  cart: "https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev",
 };
 
 export default API_PATHS;


### PR DESCRIPTION
Required scope is done.

Import service API: https://pncu28d3e3.execute-api.eu-west-1.amazonaws.com/dev/import
Import service Swagger UI: https://pncu28d3e3.execute-api.eu-west-1.amazonaws.com/dev/swagger

Product service API: https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev/products
Product service Swagger UI: https://jo936llnz4.execute-api.eu-west-1.amazonaws.com/dev/swagger

FE app: https://d1c32ya6d4q692.cloudfront.net/admin/products

Additional scope:

[+] +15 (All languages) - catalogBatchProcess lambda is covered by unit tests
[-] +15 (All languages) - set a Filter Policy for SNS createProductTopic in serverless.yml and create an additional email subscription to distribute messages to different emails depending on the filter for any product attribute